### PR TITLE
Transformation map results

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -37,6 +37,13 @@ Start by clicking open the `Docs` panel and review the introspection. Note that 
     title
     extensions {
       flexRating
+      similarProduct {
+        id
+        title
+        extensions {
+          tacoPairing { name }
+        }
+      }
       tacoPairing {
         name
         protein {
@@ -68,6 +75,6 @@ Start by clicking open the `Docs` panel and review the introspection. Note that 
 4. Requests are first validated against the composed shop schema.
   - Invalid requests return their validation errors directly.
   - Valid requests are transformed and sent to the Admin API.
-5. Results are transformed to match the shape of the original shop request.
+5. Server results are transformed to match the shape of the original shop request.
 
-While this is all being done here with a small Ruby server, this same process could work directly in a web browser in development mode. In production, we'd want to cache the transformed queries and use them directly to eliminate pre-processing. Requests always need post-processing.
+While this is all being done here with a small Ruby server, this same process could work directly in a web browser in development mode. In production, we'd want to cache the transformed queries and use them directly to eliminate pre-processing. Requests always need modest post-processing.

--- a/lib/shop_schema_client/metafield_type_resolver.rb
+++ b/lib/shop_schema_client/metafield_type_resolver.rb
@@ -24,9 +24,7 @@ module ShopSchemaClient
       end
 
       def metaobject_typename(metaobject_type)
-        metaobject_type[0] = metaobject_type[0].upcase
-        metaobject_type.gsub!(/_\w/) { _1[1].upcase }
-        "#{metaobject_type}#{METAOBJECT_TYPE_SUFFIX}"
+        "#{metaobject_type.camelize}#{METAOBJECT_TYPE_SUFFIX}"
       end
 
       def metaobject_type?(type_name)
@@ -130,10 +128,9 @@ module ShopSchemaClient
       end
 
       def unit_value_with_selections(obj, selections, type_name)
-        selections.each_with_object({}) do |node, memo|
-          # should also anticipate fragments...
-          field_name = node.alias || node.name
-          case node.name
+        selections.each_with_object({}) do |sel, memo|
+          field_name, node_name = selection_alias_and_field(sel)
+          case node_name
           when "unit"
             memo[field_name] = obj["unit"]
           when "value"
@@ -145,10 +142,9 @@ module ShopSchemaClient
       end
 
       def money_with_selections(obj, selections)
-        selections.each_with_object({}) do |node, memo|
-          # should also anticipate fragments...
-          field_name = node.alias || node.name
-          case node.name
+        selections.each_with_object({}) do |sel, memo|
+          field_name, node_name = selection_alias_and_field(sel)
+          case node_name
           when "amount"
             memo[field_name] = Float(obj["amount"])
           when "currencyCode"
@@ -160,10 +156,9 @@ module ShopSchemaClient
       end
 
       def rating_with_selections(obj, selections)
-        selections.each_with_object({}) do |node, memo|
-          # should also anticipate fragments...
-          field_name = node.alias || node.name
-          case node.name
+        selections.each_with_object({}) do |sel, memo|
+          field_name, node_name = selection_alias_and_field(sel)
+          case node_name
           when "min"
             memo[field_name] = Float(obj["scale_min"])
           when "max"
@@ -174,6 +169,10 @@ module ShopSchemaClient
             memo[field_name] = RATING_TYPENAME
           end
         end
+      end
+
+      def selection_alias_and_field(sel)
+        sel.include?(":") ? sel.split(":") : [sel, sel]
       end
     end
   end

--- a/lib/shop_schema_client/request_transformer.rb
+++ b/lib/shop_schema_client/request_transformer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "request_transformer/transformation_map"
+require_relative "request_transformer/result"
 
 module ShopSchemaClient
   class RequestTransformer
@@ -22,30 +23,23 @@ module ShopSchemaClient
       op = @query.selected_operation
       parent_type = @query.root_type_for_operation(op.operation_type)
       op = op.merge(selections: transform_scope(parent_type, op.selections))
-      # pp @transform_map.as_json
-      GraphQL::Language::Nodes::Document.new(definitions: [op, *@new_fragments.values])
+      document = GraphQL::Language::Nodes::Document.new(definitions: [op, *@new_fragments.values])
+      Result.new(document, @transform_map)
     end
 
     private
 
     def transform_scope(parent_type, input_selections, scope_type: NATIVE_SCOPE)
-      input_selections.flat_map do |node|
+      results = input_selections.flat_map do |node|
         case node
         when GraphQL::Language::Nodes::Field
-          @transform_map.step(node.name) do
+          @transform_map.field_breadcrumb(node.alias || node.name) do
             if scope_type == EXTENSIONS_SCOPE || scope_type == METAOBJECT_SCOPE
               build_metafield(parent_type, node, scope_type: scope_type)
             elsif scope_type == NATIVE_SCOPE && node.name == "extensions" && @owner_types.include?(parent_type)
               next_type = parent_type.get_field(node.name).type.unwrap
-              @transform_map.current_scope.parent.actions << TransformAction.new("ex",
-                typename: parent_type.graphql_name,
-              )
-              sel = transform_scope(next_type, node.selections, scope_type: EXTENSIONS_SCOPE)
-              sel << GraphQL::Language::Nodes::Field.new(
-                field_alias: "__typehint",
-                name: "__typename",
-              )
-              sel
+              @transform_map.current_scope.parent.has_extensions = true
+              transform_scope(next_type, node.selections, scope_type: EXTENSIONS_SCOPE)
             elsif node.selections&.any?
               next_type = parent_type.get_field(node.name).type.unwrap
               node.merge(selections: transform_scope(next_type, node.selections))
@@ -56,68 +50,68 @@ module ShopSchemaClient
 
         when GraphQL::Language::Nodes::InlineFragment
           fragment_type = node.type.nil? ? parent_type : @schema.get_type(node.type.name)
-
-          if MetafieldTypeResolver.extensions_type?(fragment_type.graphql_name)
-            transform_scope(fragment_type, node.selections, scope_type: EXTENSIONS_SCOPE)
-          elsif MetafieldTypeResolver.metaobject_type?(fragment_type.graphql_name)
-            GraphQL::Language::Nodes::InlineFragment.new(
-              type: GraphQL::Language::Nodes::TypeName.new(name: "Metaobject"),
-              selections: transform_scope(fragment_type, node.selections, scope_type: METAOBJECT_SCOPE),
-            )
-          else
-            GraphQL::Language::Nodes::InlineFragment.new(
-              type: GraphQL::Language::Nodes::TypeName.new(name: fragment_type.graphql_name),
-              selections: transform_scope(fragment_type, node.selections),
-            )
+          typed_scope(parent_type, fragment_type, scope_type) do
+            if MetafieldTypeResolver.extensions_type?(fragment_type.graphql_name)
+              transform_scope(fragment_type, node.selections, scope_type: EXTENSIONS_SCOPE)
+            elsif MetafieldTypeResolver.metaobject_type?(fragment_type.graphql_name)
+              GraphQL::Language::Nodes::InlineFragment.new(
+                type: GraphQL::Language::Nodes::TypeName.new(name: "Metaobject"),
+                selections: transform_scope(fragment_type, node.selections, scope_type: METAOBJECT_SCOPE),
+              )
+            else
+              GraphQL::Language::Nodes::InlineFragment.new(
+                type: GraphQL::Language::Nodes::TypeName.new(name: fragment_type.graphql_name),
+                selections: transform_scope(fragment_type, node.selections),
+              )
+            end
           end
 
         when GraphQL::Language::Nodes::FragmentSpread
-          unless @new_fragments[node.name]
-            fragment_def = @query.fragments[node.name]
-            fragment_type = @schema.get_type(fragment_def.type.name)
-            fragment_type_name = fragment_type.graphql_name
+          fragment_def = @query.fragments[node.name]
+          fragment_type = @schema.get_type(fragment_def.type.name)
+          typed_scope(parent_type, fragment_type, scope_type) do
+            unless @new_fragments[node.name]
+              fragment_type_name = fragment_type.graphql_name
+              fragment_selections = if MetafieldTypeResolver.extensions_type?(fragment_type.graphql_name)
+                fragment_type_name = fragment_type_name.sub(MetafieldTypeResolver::EXTENSIONS_TYPE_SUFFIX, "")
+                transform_scope(fragment_type, fragment_def.selections, scope_type: EXTENSIONS_SCOPE)
+              elsif MetafieldTypeResolver.metaobject_type?(fragment_type.graphql_name)
+                fragment_type_name = "Metaobject"
+                transform_scope(fragment_type, fragment_def.selections, scope_type: METAOBJECT_SCOPE)
+              else
+                transform_scope(fragment_type, fragment_def.selections)
+              end
 
-            fragment_selections = if MetafieldTypeResolver.extensions_type?(fragment_type.graphql_name)
-              fragment_type_name = fragment_type_name.sub(MetafieldTypeResolver::EXTENSIONS_TYPE_SUFFIX, "")
-              transform_scope(fragment_type, fragment_def.selections, scope_type: EXTENSIONS_SCOPE)
-            elsif MetafieldTypeResolver.metaobject_type?(fragment_type.graphql_name)
-              fragment_type_name = "Metaobject"
-              transform_scope(fragment_type, fragment_def.selections, scope_type: METAOBJECT_SCOPE)
-            else
-              transform_scope(fragment_type, fragment_def.selections)
+              @new_fragments[node.name] = fragment_def.merge(
+                type: GraphQL::Language::Nodes::TypeName.new(name: fragment_type_name),
+                selections: fragment_selections,
+              )
             end
 
-            @new_fragments[node.name] = fragment_def.merge(
-              type: GraphQL::Language::Nodes::TypeName.new(name: fragment_type_name),
-              selections: fragment_selections,
-            )
+            node
           end
-
-          node
         end
+      end
+
+      # @todo make results unique by field alias/name to eliminate repeat type hints
+      results
+    end
+
+    def typed_scope(parent_type, fragment_type, scope_type)
+      if scope_type == NATIVE_SCOPE && parent_type.kind.abstract?
+        possible_types = @schema.possible_types(fragment_type).map(&:graphql_name).tap(&:sort!).join("|")
+        @transform_map.type_breadcrumb(possible_types) do
+          results = Array.wrap(yield)
+          results << GraphQL::Language::Nodes::Field.new(field_alias: "__typehint", name: "__typename")
+          results
+        end
+      else
+        yield
       end
     end
 
     def build_metafield(parent_type, node, scope_type:)
-      if node.name == "__typename"
-        field_name = node.alias || node.name
-        case scope_type
-        when EXTENSIONS_SCOPE
-          @transform_map.add_action(TransformAction.new("ex_typename"))
-          return GraphQL::Language::Nodes::Field.new(
-            field_alias: "#{EXTENSIONS_PREFIX}#{field_name}",
-            name: "__typename",
-          )
-        when METAOBJECT_SCOPE
-          @transform_map.add_action(TransformAction.new("mo_typename"))
-          return GraphQL::Language::Nodes::Field.new(
-            field_alias: field_name,
-            name: "type",
-          )
-        else
-          return node
-        end
-      end
+      return build_typename(node, scope_type: scope_type) if node.name == "__typename"
 
       field = parent_type.get_field(node.name)
       metafield_attrs = field.directives.find { _1.graphql_name == "metafield" }&.arguments&.keyword_arguments
@@ -130,17 +124,25 @@ module ShopSchemaClient
       next_type = parent_type.get_field(node.name).type.unwrap
 
       selection = if is_reference && is_list
-        @transform_map.add_action(TransformAction.new("mf_references"))
+        @transform_map.add_field_transform(FieldTransform.new("mf_refs", metafield_type: type_name))
         conn_node_type = next_type.get_field("nodes").type.unwrap
         conn_selections = node.selections.map do |conn_node|
           case conn_node.name
           when "edges"
-            edges_selections = conn_node.selections.map do |n|
-              n.name == "node" ? n.merge(selections: build_metafield_reference(conn_node_type, n.selections)) : n
+            @transform_map.field_breadcrumb(conn_node.alias || conn_node.name) do
+              edges_selections = conn_node.selections.map do |n|
+                next n if n.name != "node"
+
+                @transform_map.field_breadcrumb(n.alias || n.name) do
+                  n.merge(selections: build_metafield_reference(conn_node_type, n.selections))
+                end
+              end
+              conn_node.merge(selections: edges_selections)
             end
-            conn_node.merge(selections: edges_selections)
           when "nodes"
-            conn_node.merge(selections: build_metafield_reference(conn_node_type, conn_node.selections))
+            @transform_map.field_breadcrumb(conn_node.alias || conn_node.name) do
+              conn_node.merge(selections: build_metafield_reference(conn_node_type, conn_node.selections))
+            end
           else
             conn_node
           end
@@ -152,15 +154,15 @@ module ShopSchemaClient
           selections: conn_selections,
         )
       elsif is_reference
-        @transform_map.add_action(TransformAction.new("mf_reference"))
+        @transform_map.add_field_transform(FieldTransform.new("mf_ref", metafield_type: type_name))
         GraphQL::Language::Nodes::Field.new(
           name: "reference",
           selections: build_metafield_reference(next_type, node.selections),
         )
       else
-        @transform_map.add_action(
-          TransformAction.new(
-            "mf_value",
+        @transform_map.add_field_transform(
+          FieldTransform.new(
+            "mf_val",
             metafield_type: type_name,
             selections: extract_value_selections(node.selections).presence,
           )
@@ -176,6 +178,26 @@ module ShopSchemaClient
         arguments: [GraphQL::Language::Nodes::Argument.new(name: "key", value: metafield_key)],
         selections: [selection],
       )
+    end
+
+    def build_typename(node, scope_type:)
+      field_name = node.alias || node.name
+      case scope_type
+      when EXTENSIONS_SCOPE
+        @transform_map.add_field_transform(FieldTransform.new("ex_typename"))
+        return GraphQL::Language::Nodes::Field.new(
+          field_alias: "#{EXTENSIONS_PREFIX}#{field_name}",
+          name: "__typename", # transform parent typename: Product -> ProductExtensions
+        )
+      when METAOBJECT_SCOPE
+        @transform_map.add_field_transform(FieldTransform.new("mo_typename"))
+        return GraphQL::Language::Nodes::Field.new(
+          field_alias: field_name,
+          name: "type", # transform object type: taco -> TacoMetaobject
+        )
+      else
+        node
+      end
     end
 
     def build_metafield_reference(reference_type, input_selections)

--- a/lib/shop_schema_client/request_transformer/result.rb
+++ b/lib/shop_schema_client/request_transformer/result.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module ShopSchemaClient
+  class RequestTransformer
+    class Result
+      attr_reader :document
+      attr_reader :transform_map
+
+      def initialize(document, transform_map)
+        @document = document
+        @transform_map = transform_map
+      end
+
+      def query
+        GraphQL::Language::Printer.new.print(@document)
+      end
+
+      def transforms
+        @transform_map.as_json
+      end
+
+      def as_json
+        {
+          query: query,
+          transforms: transforms,
+        }
+      end
+
+      def to_json
+        as_json.to_json
+      end
+    end
+  end
+end

--- a/test/fixtures/response.json
+++ b/test/fixtures/response.json
@@ -1,19 +1,21 @@
 {
     "data": {
-        "product": {
+        "node": {
             "id": "gid://shopify/Product/6885875646486",
             "title": "Neptune Discovery Lab",
-            "__extensions__flexRating": {
+            "__ex___typename": "Product",
+            "__ex_flexRating": {
                 "value": "1.5"
             },
-            "__extensions__similarProduct": {
+            "__ex_similarProduct": {
                 "reference": {
                     "id": "gid://shopify/Product/6561850556438",
                     "title": "Aquanauts Crystal Explorer Sub"
                 }
             },
-            "__extensions__myTaco": {
+            "__ex_myTaco": {
                 "reference": {
+                    "__typename": "taco",
                     "name": {
                         "value": "Al Pastor"
                     },
@@ -45,7 +47,8 @@
                         }
                     }
                 }
-            }
+            },
+            "__typehint": "Product"
         }
     },
     "extensions": {

--- a/test/shop_schema_client/first_test.rb
+++ b/test/shop_schema_client/first_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 describe "First Test" do
   QUERY = %|query GetProduct($id: ID!){
-    node(id: $id) { ...on Product{
+    node(id: $id) {... on Product {
       id
       title
       extensions {
@@ -28,7 +28,7 @@ describe "First Test" do
           protein {
             name
             volume {
-              value
+              sfoo:value
               unit
               __typename
             }
@@ -44,7 +44,7 @@ describe "First Test" do
         }
       }
     }
-}}
+  }}
   fragment Sfoo on ProductExtensions { flexRating }
   fragment Volume on VolumeMetatype { value unit }
   |
@@ -61,11 +61,13 @@ describe "First Test" do
     puts errors.map(&:message) if errors.any?
 
     # binding.pry
-    document2 = ShopSchemaClient::RequestTransformer.new(query).perform
-    puts GraphQL::Language::Printer.new.print(document2)
+    xform_result = ShopSchemaClient::RequestTransformer.new(query).perform
+    # puts xform_result.query
+    pp xform_result.transform_map.as_json
+    #puts JSON.pretty_generate(xform_result.transform_map.as_json)
 
-    response = JSON.parse(File.read("#{__dir__}/../fixtures/response.json"))
-    pp ShopSchemaClient::ResponseTransformer.new(shop_schema, document).perform(response["data"])
+    http_result = JSON.parse(File.read("#{__dir__}/../fixtures/response.json"))
+    pp ShopSchemaClient::ResponseTransformer.new(http_result, xform_result.transforms).perform
     assert true
   end
 end


### PR DESCRIPTION
Switches results transformation to use mapping strategy rather than schema. This makes production requests fully autonomous without dependencies on a large hydrated schema.